### PR TITLE
Change Infra Reset Creds to Email Notification

### DIFF
--- a/routes/infra.py
+++ b/routes/infra.py
@@ -20,6 +20,8 @@ from util.errors import Errors
 from util.options import Options
 from util.approve import Approve
 from util.discord import Discord
+from util.email import Email
+
 from util.kennelish import Kennelish, Transformer
 
 from python_terraform import *
@@ -306,6 +308,8 @@ Happy Hacking,
             """
 
     # Send Discord message
-    Discord.send_message(user_data.get("discord_id"), new_creds_msg)
+    #Discord.send_message(user_data.get("discord_id"), new_creds_msg)
+    # Send Email
+    Email.send_email("Reset Infra Credentials", new_creds_msg, user_data.get("email") )
 
     return {"username": creds.get("username"), "password": creds.get("password")}

--- a/util/email.py
+++ b/util/email.py
@@ -1,0 +1,30 @@
+import smtplib, ssl
+from email.mime.text import MIMEText
+from util.options import Options
+
+options = Options.fetch()
+
+
+#from util.options import Options
+options = Options.fetch()
+
+email = options.get('email', {}).get('email', {})
+password = options.get('email', {}).get('password', {})
+smtp_host = options.get('email', {}).get('smtp_server', {})
+print(email)
+print(password)
+print(smtp_host)
+class Email:
+    """
+    This function handles sending emails.
+    """
+    def send_email(subject, body, recipient):
+        msg = MIMEText(body)
+        msg['Subject'] = subject
+        msg['From'] = email
+        msg['To'] = recipient
+        with smtplib.SMTP_SSL(smtp_host, 465) as smtp_server:
+           print(msg.as_string())
+           smtp_server.login(email, password)
+           smtp_server.sendmail(email, recipient, msg.as_string())
+        


### PR DESCRIPTION
Temporary patch to allow the infra reset creds message to be sent over email instead of discord. The correct way to implement would to create a notifcation handler function. I was unable to test the reset functionality as a whole but the email.py was confirmed working.
added config options
```
email:
    smtp_server:
    email:
    password:
 ```