### PR TITLE
Replaced weak gets() calls with direct key lookups.

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -16,6 +16,7 @@ from util.errors import Errors
 from util.options import Options
 
 options = Options.fetch()
+DYNAMO_USERS_TABLE = options['aws']['dynamodb']['table']
 
 templates = Jinja2Templates(directory="templates")
 
@@ -30,8 +31,8 @@ async def admin(request: Request, token: Optional[str] = Cookie(None)):
     """
     payload = jwt.decode(
         token,
-        options.get("jwt").get("secret"),
-        algorithms=options.get("jwt").get("algorithm"),
+        options["jwt"]["secret"],
+        algorithms=options["jwt"]["algorithm"],
     )
     return templates.TemplateResponse(
         "admin_searcher.html",
@@ -66,7 +67,7 @@ async def get_infra(
 
     # Get user data
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
 
     user_data = table.get_item(Key={"id": member_id}).get("Item", None)
 
@@ -75,16 +76,16 @@ async def get_infra(
 
 We are happy to grant you Hack@UCF Private Cloud access!
 
-These credentials can be used to the Hack@UCF Private Cloud. This can be accessed at {options.get('infra', {}).get('horizon')} while on the CyberLab WiFi.
+These credentials can be used to the Hack@UCF Private Cloud. This can be accessed at {options['infra']['horizon']} while on the CyberLab WiFi.
 
 ```
 Username: {creds.get('username', 'Not Set')}
-Password: {creds.get('password', f"Please visit https://{options.get('http', {}).get('domain')}/profile and under Danger Zone, reset your Infra creds.")}
+Password: {creds.get('password', f"Please visit https://{options['http']['domain']}/profile and under Danger Zone, reset your Infra creds.")}
 ```
 
 By using the Hack@UCF Infrastructure, you agree to the following EULA located at https://help.hackucf.org/misc/eula
 
-The password for the `Cyberlab` WiFi is currently `{options.get('infra', {}).get('wifi')}`, but this is subject to change (and we'll let you know when that happens).
+The password for the `Cyberlab` WiFi is currently `{options['infra']['wifi']}`, but this is subject to change (and we'll let you know when that happens).
 
 Happy Hacking,
   - Hack@UCF Bot
@@ -112,7 +113,7 @@ async def get_refresh(
     Approve.approve_member(member_id)
 
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     data = table.get_item(Key={"id": member_id}).get("Item", None)
 
     if not data:
@@ -135,7 +136,7 @@ async def admin_get_single(
         return {"data": {}, "error": "Missing ?member_id"}
 
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     data = table.get_item(Key={"id": member_id}).get("Item", None)
 
     if not data:
@@ -159,7 +160,7 @@ async def admin_get_snowflake(
         return {"data": {}, "error": "Missing ?discord_id"}
 
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     data = table.scan(FilterExpression=Attr("discord_id").eq(str(discord_id))).get(
         "Items"
     )
@@ -196,7 +197,7 @@ async def admin_post_discord_message(
         return {"data": {}, "error": "Missing ?member_id"}
 
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     data = table.get_item(Key={"id": member_id}).get("Item", None)
 
     if not data:
@@ -225,7 +226,7 @@ async def admin_edit(
     member_id = input_data.id
 
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     old_data = table.get_item(Key={"id": member_id}).get("Item", None)
 
     if not old_data:
@@ -255,7 +256,7 @@ async def admin_list(request: Request, token: Optional[str] = Cookie(None)):
     API endpoint that dumps all users as JSON.
     """
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     data = table.scan().get("Items", None)
     return {"data": data}
 
@@ -267,7 +268,7 @@ async def admin_list_csv(request: Request, token: Optional[str] = Cookie(None)):
     API endpoint that dumps all users as CSV.
     """
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
     data = table.scan().get("Items", None)
 
     output = "Membership ID, First Name, Last Name, NID, Is Returning, Gender, Major, Class Standing, Shirt Size, Discord Username, Experience, Cyber Interests, Event Interest, Is C3 Interest, Comments, Ethics Form Timestamp, Minecraft, Infra Email\n"

--- a/routes/api.py
+++ b/routes/api.py
@@ -15,6 +15,7 @@ from util.kennelish import Kennelish, Transformer
 from util.options import Options
 
 options = Options.fetch()
+DYNAMO_USERS_TABLE = options['aws']['dynamodb']['table']
 
 router = APIRouter(prefix="/api", tags=["API"], responses=Errors.basic_http())
 
@@ -65,7 +66,7 @@ async def get_form_html(
 ):
     # AWS dependencies
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
 
     # Get form object
     data = Options.get_form_body(num)
@@ -138,7 +139,7 @@ async def post_form(
 
     # AWS dependencies
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
 
     # Push data back to DynamoDB
     try:

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -21,6 +21,7 @@ from util.limiter import RateLimiter
 from util.options import Options
 
 options = Options.fetch()
+DYNAMO_USERS_TABLE = options['aws']['dynamodb']['table']
 
 templates = Jinja2Templates(directory="templates")
 
@@ -29,9 +30,9 @@ router = APIRouter(prefix="/infra", tags=["Infra"], responses=Errors.basic_http(
 tf = Terraform(working_dir="./")
 
 rate_limiter = RateLimiter(
-    options.get("redis").get("host"),
-    options.get("redis").get("port"),
-    options.get("redis").get("db"),
+    options["redis"]["host"],
+    options["redis"]["port"],
+    options["redis"]["db"],
 )
 
 rate_limiter.get_redis()
@@ -60,8 +61,8 @@ async def create_resource(project, callback_discord_id=None):
     print(f"Creating resources for {proj_name}...")
 
     tf_vars = {
-        "username": options.get("infra", {}).get("ad", {}).get("username"),
-        "password": options.get("infra", {}).get("ad", {}).get("password"),
+        "username": options["infra"]["ad"]['username'],
+        "password": options["infra"]["ad"]['password'],
         "tenant_name": proj_name,
         "gbmname": shitty_database.get("gbmName"),
         "imageid": shitty_database.get("imageId"),
@@ -87,7 +88,7 @@ async def create_resource(project, callback_discord_id=None):
     if callback_discord_id:
         resource_create_msg = f"""Hello!
 
-Your requested virtual machine has been created! You can now view it at {options.get('infra', {}).get('horizon')}.
+Your requested virtual machine has been created! You can now view it at {options['infra']['horizon']}
 
 Enjoy,
     - Hack@UCF Bot
@@ -286,7 +287,7 @@ async def get_infra(
 
     # Get user data
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(DYNAMO_USERS_TABLE)
 
     user_data = table.get_item(Key={"id": member_id}).get("Item", None)
 
@@ -295,14 +296,14 @@ async def get_infra(
 
 You have requested to reset your Hack@UCF Infrastructure credentials. This change comes with new credentials.
 
-A reminder that you can use these credentials at {options.get('infra', {}).get('horizon')} while on the CyberLab WiFi.
+A reminder that you can use these credentials at {options['infra']['horizon']} while on the CyberLab WiFi.
 
 ```
 Username: {creds.get('username', 'Not Set')}
-Password: {creds.get('password', f"Please visit https://{options.get('http', {}).get('domain')}/profile and under Danger Zone, reset your Infra creds.")}
+Password: {creds.get('password', f"Please visit https://{options['http']['domain']}/profile and under Danger Zone, reset your Infra creds.")}
 ```
 
-The password for the `Cyberlab` WiFi is currently `{options.get('infra', {}).get('wifi')}`, but this is subject to change (and we'll let you know when that happens).
+The password for the `Cyberlab` WiFi is currently `{options['infra']['wifi']}`, but this is subject to change (and we'll let you know when that happens).
 
 By using the Hack@UCF Infrastructure, you agree to the following EULA located at https://help.hackucf.org/misc/eula
 

--- a/routes/stripe.py
+++ b/routes/stripe.py
@@ -18,7 +18,7 @@ templates = Jinja2Templates(directory="templates")
 router = APIRouter(prefix="/pay", tags=["API"], responses=Errors.basic_http())
 
 # Set Stripe API key.
-stripe.api_key = options.get("stripe").get("api_key")
+stripe.api_key = options['stripe']['api_key']
 
 """
 Get API information.
@@ -34,7 +34,7 @@ async def get_root(
 ):
     # AWS dependencies
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(options['aws']['dynamodb']['table'])
 
     # Get data from DynamoDB
     user_data = table.get_item(Key={"id": payload.get("id")}).get("Item", None)
@@ -65,7 +65,7 @@ async def create_checkout_session(
 ):
     # AWS dependencies
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(options['aws']['dynamodb']['table'])
 
     # Get data from DynamoDB
     user_data = table.get_item(Key={"id": payload.get("id")}).get("Item", None)
@@ -76,14 +76,14 @@ async def create_checkout_session(
             line_items=[
                 {
                     # Provide the exact Price ID (for example, pr_1234) of the product you want to sell
-                    "price": options.get("stripe").get("price_id"),
+                    "price": options['stripe']['price_id'],
                     "quantity": 1,
                 },
             ],
             customer_email=stripe_email,
             mode="payment",
-            success_url=options.get("stripe").get("url").get("success"),
-            cancel_url=options.get("stripe").get("url").get("failure"),
+            success_url=options['stripe']['url']['success'],
+            cancel_url=options['stripe']['url']['failure']
         )
     except Exception as e:
         return str(e)
@@ -96,7 +96,7 @@ async def webhook(request: Request):
     payload = await request.body()
     sig_header = request.headers.get("stripe-signature")
     event = None
-    endpoint_secret = options.get("stripe").get("webhook_secret")
+    endpoint_secret = options['stripe']['webhook_secret']
 
     try:
         event = stripe.Webhook.construct_event(payload, sig_header, endpoint_secret)
@@ -137,7 +137,7 @@ def pay_dues(session):
 
     # AWS dependencies
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(options['aws']['dynamodb']['table'])
 
     # Get data from DynamoDB
     response = table.scan(FilterExpression=Attr("email").eq(customer_email)).get(

--- a/routes/wallet.py
+++ b/routes/wallet.py
@@ -240,7 +240,7 @@ async def aapl_gen(
     payload: Optional[object] = {},
 ):
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table(options.get("aws").get("dynamodb").get("table"))
+    table = dynamodb.Table(options["aws"]["dynamodb"]["table"])
 
     # Get data from DynamoDB
     user_data = table.get_item(Key={"id": payload.get("id")}).get("Item", None)

--- a/util/authentication.py
+++ b/util/authentication.py
@@ -30,8 +30,8 @@ class Authentication:
             try:
                 payload = jwt.decode(
                     token,
-                    options.get("jwt").get("secret"),
-                    algorithms=options.get("jwt").get("algorithm"),
+                    options['jwt']['secret'],
+                    algorithms=options['jwt']['algorithm']
                 )
                 is_admin: bool = payload.get("sudo", False)
                 creation_date: float = payload.get("issued", -1)
@@ -52,9 +52,7 @@ class Authentication:
                     essay="If you think this is an error, please try logging in again.",
                 )
 
-            if time.time() > creation_date + options.get("jwt").get("lifetime").get(
-                "sudo"
-            ):
+            if time.time() > creation_date + options["jwt"]["lifetime"]["sudo"]:
                 return Errors.generate(
                     request,
                     403,
@@ -86,8 +84,8 @@ class Authentication:
             try:
                 payload = jwt.decode(
                     token,
-                    options.get("jwt").get("secret"),
-                    algorithms=options.get("jwt").get("algorithm"),
+                    options['jwt']['secret'],
+                    algorithms=options['jwt']['algorithm']
                 )
                 creation_date: float = payload.get("issued", -1)
             except Exception:
@@ -99,9 +97,7 @@ class Authentication:
                 tr.delete_cookie(key="token")
                 return tr
 
-            if time.time() > creation_date + options.get("jwt").get("lifetime").get(
-                "user"
-            ):
+            if time.time() > creation_date + options['jwt']['lifetime']['user']:
                 return Errors.generate(
                     request,
                     403,

--- a/util/discord.py
+++ b/util/discord.py
@@ -7,7 +7,7 @@ from util.options import Options
 options = Options.fetch()
 
 headers = {
-    "Authorization": f"Bot {options.get('discord', {}).get('bot_token')}",
+    "Authorization": f"Bot {options['discord']['bot_token']}",
     "Content-Type": "application/json",
     "X-Audit-Log-Reason": "Hack@UCF OnboardLite Bot",
 }
@@ -25,7 +25,7 @@ class Discord:
         discord_id = str(discord_id)
 
         req = requests.put(
-            f"https://discord.com/api/guilds/{options.get('discord', {}).get('guild_id')}/members/{discord_id}/roles/{role_id}",
+            f"https://discord.com/api/guilds/{options['discord']['guild_id']}/members/{discord_id}/roles/{role_id}",
             headers=headers,
         )
 

--- a/util/email.py
+++ b/util/email.py
@@ -12,11 +12,9 @@ options = Options.fetch()
 # from util.options import Options
 options = Options.fetch()
 
-email = options.get("email", {}).get("email", {})
-
-email = options.get("email", {}).get("email", {})
-password = options.get("email", {}).get("password", {})
-smtp_host = options.get("email", {}).get("smtp_server", {})
+email = options['email']['email']
+password = options['email']['password']
+smtp_host = options['email']['smtp_server']
 
 
 class Email:


### PR DESCRIPTION
There were alot of cases of using a.get('b').get('c').get('d') which would except with an `AttributeError` in the case of a failed lookup midway through. Replaced these with straightforward `a['b']['c']['d']` instead.

A better solution around options would be to have a Pydantic model with required fields instead thus solving the issue at it's root. Currently even with this PR there's a solid chance of a runtime exception due to a misconfiguration that can't be caught without executing the code across a wide coverage of functions.