### PR TITLE
ci: add ruff workflow with PR annotations, fix lint violations

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,5 +19,5 @@ jobs:
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - run: echo "SKIP=semgrep" >> $GITHUB_ENV
+      - run: echo "SKIP=semgrep,ruff,ruff-format" >> $GITHUB_ENV
       - run: uv run pre-commit run --all-files

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,14 @@
+name: Ruff
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+      - run: uv run ruff check --output-format=github
+      - run: uv run ruff format --check

--- a/app/entry.py
+++ b/app/entry.py
@@ -9,7 +9,6 @@ import sys
 def run_uvicorn():
     host = os.getenv("ONBOARD_HOST", "0.0.0.0")
     port = os.getenv("ONBOARD_PORT", "8000")
-    proxy_headers = os.getenv("ONBOARD_PROXY_HEADERS")
     forwarded_allow_ips = os.getenv("ONBOARD_FORWARDED_ALLOW_IPS")
 
     command = [

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024 Collegiate Cyber Defense Club
+import json
 import logging
 import os
 import uuid

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024 Collegiate Cyber Defense Club
-import json
 import logging
 import os
 import uuid
 from typing import Optional
 
 import sentry_sdk
-
 from fastapi import BackgroundTasks, Cookie, Depends, FastAPI, Request, Response, status
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import FileResponse, RedirectResponse
@@ -28,7 +26,6 @@ from app.models.user import (
 
 # Import routes
 from app.routes import admin, api, infra, stripe, wallet
-
 from app.util.approve import Approve
 
 # Import middleware

--- a/app/migrations/versions/c461357e905b_enforce_unique_constrant_on_discord_.py
+++ b/app/migrations/versions/c461357e905b_enforce_unique_constrant_on_discord_.py
@@ -11,7 +11,6 @@ before running this migration if necessary.
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/app/util/approve.py
+++ b/app/util/approve.py
@@ -143,14 +143,14 @@ class Approve:
                 # Create an Infra account.
                 try:
                     creds = Approve.provision_infra(member_id, user_data)
-                except:
+                except Exception:
                     logger.exception("Failed to provision user account")
                     creds = {"username": None, "password": None}
 
                 # Assign the Dues-Paying Member role
                 try:
                     Discord.assign_role(discord_id, Settings().discord.member_role)
-                except:
+                except Exception:
                     logger.exception("Failed to assign role")
 
                 # Send Discord message saying they are a member

--- a/app/util/auth_dependencies.py
+++ b/app/util/auth_dependencies.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024 Collegiate Cyber Defense Club
-import hashlib
 import logging
 import time
 import uuid

--- a/app/util/csrf.py
+++ b/app/util/csrf.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from urllib.parse import urlparse
 
 from fastapi import Request, Response

--- a/app/util/settings.py
+++ b/app/util/settings.py
@@ -12,17 +12,12 @@ import yaml
 from joserfc.jwk import OctKey
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings
-from requests_oauthlib.oauth1_session import OAuth1
 
 logger = logging.getLogger(__name__)
 
 config_file = pathlib.Path(os.getenv("ONBOARD_CONFIG_FILE", "config.yml")).resolve()
 onboard_env = os.getenv("ONBOARD_ENV", "prod")
 loglevel = os.getenv("ONBOARD_LOGLEVEL", "INFO")
-
-if onboard_env == "dev":
-    import hashlib
-    import socket
 
 
 def BitwardenConfig(settings: dict):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,4 @@
 line-length = 200
+
+[lint]
+select = ["E4", "E7", "E9", "F", "I"]

--- a/tests/test_discord_update.py
+++ b/tests/test_discord_update.py
@@ -1,23 +1,19 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024 Collegiate Cyber Defense Club
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.main import update_discord_model_for_existing_user
-from app.models.user import DiscordModel, UserModel
+from app.models.user import UserModel
 
 
 def test_update_discord_model_for_existing_user(session: Session, test_user: UserModel):
     """Test that the background task updates Discord model for existing users"""
 
     # Setup test data - simulate Discord API response
-    original_username = test_user.discord.username
-    original_avatar = test_user.discord.avatar
-
     discord_data = {
         "id": test_user.discord_id,
         "email": "updated_email@example.com",


### PR DESCRIPTION
## Summary
- New `.github/workflows/ruff.yaml` runs `ruff check --output-format=github` and `ruff format --check` on pushes/PRs to `dev`/`main`. The `github` output format renders violations as inline PR annotations.
- Fixed the 14 existing `ruff check` failures so the new workflow is green:
  - Removed unused imports in `app/util/auth_dependencies.py`, `app/util/csrf.py`, `app/util/settings.py`, `app/migrations/versions/c461357e905b_enforce_unique_constrant_on_discord_.py`, and `tests/test_discord_update.py`.
  - Replaced two bare `except:` clauses in `app/util/approve.py` with `except Exception:`.
  - Dropped the unused `proxy_headers` local in `app/entry.py` and the unused `original_username` / `original_avatar` locals in the Discord update test.
  - Removed the now-empty `if onboard_env == "dev":` block in `app/util/settings.py` that only held two unused imports.

## Test plan
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyrefly check`
- [x] `uv run pytest tests/`
- [ ] Confirm new `Ruff` workflow runs and would annotate inline if a violation were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)