### PR TITLE
Warn users that dues reset annually in August before paying

### DIFF
--- a/app/routes/stripe.py
+++ b/app/routes/stripe.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024 Collegiate Cyber Defense Club
 import logging
 import uuid
+from datetime import datetime
 
 import stripe
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
@@ -46,6 +47,7 @@ async def get_root(
     user_data = user_to_dict(user_data)
 
     paused_payments = Settings().stripe.pause_payments
+    dues_restart_soon = datetime.utcnow().month > 4
 
     return templates.TemplateResponse(
         request,
@@ -54,6 +56,7 @@ async def get_root(
             "user_data": user_data,
             "did_pay_dues": did_pay_dues,
             "paused_payments": paused_payments,
+            "dues_restart_soon": dues_restart_soon,
         },
     )
 

--- a/app/templates/pay.html
+++ b/app/templates/pay.html
@@ -30,6 +30,12 @@
                 <li>A free t-shirt.</li>
             </ul>
             <p>While we highly recommend paying dues, they are not required for most of our events.</p>
+            {% if dues_restart_soon and not did_pay_dues %}
+            <div class="alert">
+                <span class="closebtn dismiss-alert">&times;</span>
+                Heads up: membership dues reset annually in August. If you pay now, you'll need to pay dues again once the new membership year starts in August.
+            </div>
+            {% endif %}
             <p><i>Want to pay dues in person?</i> Press Skip and contact an Executive at our next event.</p>
             <div class="entry">
                 <div>


### PR DESCRIPTION
## Summary
- Show an alert on the Pay Dues page when paying after April, warning that membership dues reset annually in August and will need to be paid again once the new membership year starts.
- Only shown to users who haven't already paid dues.

## Test plan
- [ ] Visit `/pay/` with a mocked date in May-Dec and confirm the warning appears above the "Pay Dues" button (when dues not yet paid).
- [ ] Visit `/pay/` with a mocked date in Jan-Apr and confirm the warning does not appear.
- [ ] Confirm warning does not appear for a user who has already paid dues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)