### PR TITLE
fix: pin docker compose network MTU to match infra tunnel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,10 @@ services:
     volumes:
       - ./config/options.yml:/src/config/options.yml
       - ./database/:/data/
+    networks:
+      - default
+
+networks:
+  default:
+    driver_opts:
+      com.docker.network.driver.mtu: 1368


### PR DESCRIPTION
## Summary
- Admin infra provisioning (`/admin` -> `Approve.provision_infra`) was failing in prod with `KeycloakConnectionError: Can't connect to server` after ~60s timeouts talking to `admin-sso.hackucf.cloud`.
- Traced it to a Docker+VPN MTU mismatch: `admin-sso.hackucf.cloud` is only reachable via the host's `infra` tunnel interface (MTU 1368), but the fastapi container's default bridge network uses MTU 1500. The container's TCP stack builds packets sized for 1500, they get silently dropped once forwarded onto the 1368 tunnel (PMTU blackhole — the ICMP "fragmentation needed" doesn't make it back into the container's netns), so anything past the small SYN/ACK packets just hangs.
- Confirmed via `docker exec ... curl -v` reproducing the hang, `ip route get`/`ip link show infra` showing the 1368 MTU tunnel, and the raw host curl (not going through the docker bridge) working fine.
- Fix: pin the compose default network's MTU to 1368 so container-originated packets never exceed what the tunnel can actually carry.

## Test plan
- [ ] `docker compose down && docker compose up -d` on the affected host to recreate the network with the new MTU
- [ ] Re-run `docker exec <container> curl -v https://admin-sso.hackucf.cloud/realms/prod/protocol/openid-connect/token -d grant_type=password -d client_id=admin-cli` and confirm it returns promptly instead of hanging
- [ ] Confirm admin infra provisioning (`/admin` enable/provision flow) succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)