### PR TITLE
fix: read Stripe webhook fields with getattr, not dict access

### DIFF
--- a/app/routes/stripe.py
+++ b/app/routes/stripe.py
@@ -129,7 +129,7 @@ async def webhook(request: Request, background_tasks: BackgroundTasks, session: 
         # Retrieve the session. If you require line items in the response, you may include them by expanding line_items.
         checkout_session = event["data"]["object"]
 
-        if checkout_session.payment_status == "paid":
+        if getattr(checkout_session, "payment_status", None) == "paid":
             # Mark as paid.
             pay_dues(checkout_session, session, background_tasks)
 
@@ -148,9 +148,13 @@ def resolve_paying_user(checkout_session, db_session):
     create_checkout_session stamps the user id into session metadata, so prefer
     that: it is exact and survives the user changing their email afterwards.
     Fall back to email only for sessions created before that was relied on.
+
+    Read every field with getattr: Stripe hands us a StripeObject, which is not
+    a dict (no ``.get()``), and missing fields raise AttributeError rather than
+    returning None.
     """
-    metadata = getattr(checkout_session, "metadata", None) or {}
-    raw_user_id = metadata.get("user_id")
+    metadata = getattr(checkout_session, "metadata", None)
+    raw_user_id = getattr(metadata, "user_id", None)
 
     if raw_user_id:
         try:
@@ -163,7 +167,7 @@ def resolve_paying_user(checkout_session, db_session):
                 return user_data
             logger.warning("Stripe webhook: metadata user_id %s not found, falling back to email", member_id)
 
-    customer_email = checkout_session.customer_email
+    customer_email = getattr(checkout_session, "customer_email", None)
     if not customer_email:
         # Blank emails are common (incomplete signups), so an empty lookup here
         # would match many rows rather than none.
@@ -199,7 +203,7 @@ def pay_dues(checkout_session, db_session, background_tasks):
         checkout_session_id=session_id,
         amount_cents=getattr(checkout_session, "amount_total", None),
         currency=getattr(checkout_session, "currency", None),
-        customer_email=checkout_session.customer_email,
+        customer_email=getattr(checkout_session, "customer_email", None),
     )
 
     # Set PAID.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import uuid
 
 import pytest
+import stripe
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
@@ -127,22 +128,28 @@ def admin_jwt_fixture(admin_user: UserModel):
     return Authentication.create_jwt(admin_user)
 
 
-class FakeCheckoutSession:
+def make_checkout_session(id="cs_test_123", customer_email=None, metadata=None, amount_total=1000, currency="usd", payment_status="paid"):
     """
-    Stand-in for stripe.checkout.Session. The real object is attribute-accessed
-    (``.customer_email``, ``.metadata``), so a plain namespace is enough and
-    avoids pulling in a Stripe mocking dependency the project doesn't have.
-    """
+    Build a real ``stripe.checkout.Session`` from a raw payload, exactly as
+    ``stripe.Webhook.construct_event`` does in the webhook route.
 
-    def __init__(self, id="cs_test_123", customer_email=None, metadata=None, amount_total=1000, currency="usd", payment_status="paid"):
-        self.id = id
-        self.customer_email = customer_email
-        self.metadata = metadata if metadata is not None else {}
-        self.amount_total = amount_total
-        self.currency = currency
-        self.payment_status = payment_status
+    Deliberately not a hand-rolled namespace. ``StripeObject`` is not a dict —
+    it has no ``.get()`` — and because it defines ``__getattr__`` no type
+    checker will flag the difference. A dict-based stand-in therefore accepts
+    calls that raise ``AttributeError`` against the real object in production.
+    """
+    payload = {
+        "id": id,
+        "object": "checkout.session",
+        "customer_email": customer_email,
+        "metadata": metadata if metadata is not None else {},
+        "amount_total": amount_total,
+        "currency": currency,
+        "payment_status": payment_status,
+    }
+    return stripe.checkout.Session.construct_from(payload, None)
 
 
 @pytest.fixture(name="checkout_session_factory")
 def checkout_session_factory_fixture():
-    return FakeCheckoutSession
+    return make_checkout_session


### PR DESCRIPTION
## The bug

Every live `checkout.session.completed` webhook is returning **HTTP 500** in production:

```
AttributeError: get
  app/routes/stripe.py in resolve_paying_user at line 153
  app/routes/stripe.py in pay_dues at line 189
  app/routes/stripe.py in webhook at line 134
```

`resolve_paying_user` did `metadata.get("user_id")`. Stripe's `StripeObject` is **not** a dict subclass (`stripe==15.5.0`, MRO is `(StripeObject, object)`) — it has no `.get()`, no `.keys()`, and isn't iterable. Its `__getattr__` turns the missing attribute into `AttributeError`.

Impact: no `PaymentModel` row written, `did_pay_dues` not set, member not promoted. Stripe retries failed webhooks for up to 3 days, so sessions that 500'd should self-heal on redelivery once this ships — the `checkout_session_id` dedup makes replay safe.

Introduced in #402.

## The fix

Read every field off the session with `getattr(..., default)` — supported by `StripeObject.__getattr__`, and it tolerates fields Stripe omits instead of raising. Applied to `metadata`, `customer_email`, `id`, `amount_total`, `currency`, and `payment_status`.

No helper/shim: in production these are always `StripeObject`s, and `getattr` is all they need.

## Why neither CI gate caught it

**Type checking cannot catch this.** `StripeObject` defines `__getattr__(self, k)` returning unannotated `Any` (`_stripe_object.py:163`), which tells any checker *"I have every attribute."* Even a fully annotated call passes:

```python
def annotated(checkout_session: stripe.checkout.Session):
    return checkout_session.metadata.get("user_id")   # pyrefly: 0 errors
```

(`Session.metadata` is declared `Optional[UntypedStripeObject[str]]`, and `UntypedStripeObject` subclasses `StripeObject`.)

**The tests were the real gap.** `FakeCheckoutSession` was a hand-rolled namespace holding a plain `dict`, which *does* have `.get()` — so the fake passed where the real object fails. Replaced with `stripe.checkout.Session.construct_from(...)`, the same constructor `stripe.Webhook.construct_event` uses, so the suite now exercises the real object model.

Verified the new fixture reproduces the production failure against the old code:

```
session type : Session
metadata type: StripeObject
NEW code -> a57e49b6-...
OLD code -> AttributeError: get   <-- reproduces production
```

## Testing

- `uv run pytest` — 27 passed, 1 skipped. (`test_openvpn` fails on `dev` too; pre-existing, local-config dependent.)
- `uv run ruff check` / `ruff format --check` — clean.
- `uv run pyrefly check` — no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
