### PR TITLE
feat: record dues payment when Stripe returns the member

### DIFF
--- a/app/routes/stripe.py
+++ b/app/routes/stripe.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2024 Collegiate Cyber Defense Club
 import logging
 import uuid
+from typing import Optional
+from urllib.parse import urlencode, urlparse, urlunparse
 
 import stripe
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
@@ -62,6 +64,30 @@ async def get_root(
     )
 
 
+PAY_FINAL_PATH = "/pay/final"
+
+
+def build_success_url(url_success: str) -> str:
+    """
+    Where Stripe sends the member after a successful checkout.
+
+    Only the scheme and host are taken from config; the path is pinned to the
+    route that actually reconciles the payment. Leaving the path configurable
+    means a stale config silently lands members on a page that ignores the
+    session id — the checkout still looks fine and nothing is ever recorded.
+    That failure is invisible, so it isn't worth the flexibility.
+
+    ``{CHECKOUT_SESSION_ID}`` is Stripe's template token; it substitutes the
+    real session id on redirect.
+    """
+    parts = urlparse(url_success)
+    if parts.path.rstrip("/") not in ("", PAY_FINAL_PATH):
+        logger.info("Overriding configured stripe.url_success path %r with %s", parts.path, PAY_FINAL_PATH)
+    # safe="{}" keeps the braces literal; Stripe matches on them verbatim.
+    query = urlencode({"session_id": "{CHECKOUT_SESSION_ID}"}, safe="{}")
+    return urlunparse(parts._replace(path=PAY_FINAL_PATH, query=query, params="", fragment=""))
+
+
 @router.post("/checkout")
 async def create_checkout_session(
     request: Request,
@@ -90,7 +116,7 @@ async def create_checkout_session(
             ],
             customer_email=stripe_email,
             mode="payment",
-            success_url=Settings().stripe.url_success,  # type: ignore[bad-argument-type]
+            success_url=build_success_url(Settings().stripe.url_success),  # type: ignore[bad-argument-type]
             cancel_url=Settings().stripe.url_failure,  # type: ignore[bad-argument-type]
             metadata={"user_id": str(user_id)},
         )
@@ -221,3 +247,64 @@ def pay_dues(checkout_session, db_session, background_tasks):
 
     # Do checks to approve membership status in background.
     background_tasks.add_task(Approve.approve_member, member_id, notify_on_failure=True)
+
+
+@router.get("/final")
+async def pay_final(
+    request: Request,
+    current_user: CurrentMember,
+    background_tasks: BackgroundTasks,
+    session_id: Optional[str] = None,
+    session: Session = Depends(get_session),
+):
+    """
+    Where Stripe returns the member after a successful checkout.
+
+    The webhook stays the source of truth, but it can be delayed or fail
+    outright. When that happens the member gets no confirmation, sees the Pay
+    button again on their next visit, and pays twice — which has happened.
+    Recording the payment here too closes that window.
+
+    pay_dues dedups on checkout_session_id, so this and the webhook race
+    harmlessly: whichever arrives first wins and the other is a no-op.
+    """
+    # Deliberately not gated on pause_payments: pausing stops new sessions
+    # being created, but a member returning from one created beforehand still
+    # needs crediting. An unset API key surfaces as a StripeError below.
+    if session_id:
+        try:
+            checkout_session = stripe.checkout.Session.retrieve(session_id)
+        except stripe.StripeError:
+            # Never block the confirmation page on Stripe being reachable; the
+            # webhook is still coming.
+            logger.exception("Could not retrieve checkout session %s on return", session_id)
+        else:
+            if session_belongs_to(checkout_session, current_user):
+                if getattr(checkout_session, "payment_status", None) == "paid":
+                    pay_dues(checkout_session, session, background_tasks)
+            else:
+                logger.warning(
+                    "User %s returned with checkout session %s belonging to someone else",
+                    current_user.get("id"),
+                    session_id,
+                )
+
+    return templates.TemplateResponse(request, "done.html")
+
+
+def session_belongs_to(checkout_session, current_user) -> bool:
+    """
+    Whether this checkout session was created for the logged-in member.
+
+    Session ids arrive in a query string the member controls, so confirm
+    ownership before crediting anyone. Compare parsed UUIDs rather than raw
+    strings so formatting differences can't cause a false mismatch.
+    """
+    metadata = getattr(checkout_session, "metadata", None)
+    raw_user_id = getattr(metadata, "user_id", None)
+    if not raw_user_id:
+        return False
+    try:
+        return uuid.UUID(str(raw_user_id)) == uuid.UUID(str(current_user.get("id")))
+    except (ValueError, TypeError):
+        return False

--- a/options-example.yml
+++ b/options-example.yml
@@ -28,7 +28,9 @@ stripe:
   api_key: "your_stripe_api_key_here"
   webhook_secret: "your_stripe_webhook_secret_here"
   price_id: "your_stripe_price_id_here"
-  url_success: "https://join.hackucf.org/final/"
+  # Only the scheme and host are used; the path is pinned to /pay/final,
+  # the route that records the payment on return from Stripe.
+  url_success: "https://join.hackucf.org/pay/final"
   url_failure: "https://join.hackucf.org/pay/"
   pause_payments: true
 

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -5,14 +5,16 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
+import stripe
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 from sqlalchemy import update
 from sqlmodel import Session, select
 
 from app.models.user import EthicsFormModel, MembershipHistoryModel, PaymentModel, UserModel
-from app.routes.stripe import pay_dues
+from app.routes.stripe import build_success_url, pay_dues
 from app.util.approve import Approve
+from app.util.auth_dependencies import Authentication
 from app.util.membership_reset import MembershipReset
 
 
@@ -337,3 +339,118 @@ def test_last_reset_date_derives_from_history(session: Session):
     session.commit()
 
     assert MembershipReset.get_last_reset_date(session).year == 2026
+
+
+# --- /pay/final: reconciling on return from Stripe -------------------------------
+
+
+def test_build_success_url_adds_placeholder():
+    """Stripe's template token must survive URL encoding verbatim."""
+    assert build_success_url("https://join.hackucf.org/pay/final") == "https://join.hackucf.org/pay/final?session_id={CHECKOUT_SESSION_ID}"
+
+
+def test_build_success_url_pins_stale_configured_path():
+    """
+    Regression: a config still pointing at /final/ sent members to a page that
+    ignores session_id, so the payment was never recorded and checkout looked
+    successful. Only the origin is taken from config.
+    """
+    assert build_success_url("https://join.hackucf.org/final/") == "https://join.hackucf.org/pay/final?session_id={CHECKOUT_SESSION_ID}"
+
+
+def test_build_success_url_keeps_scheme_and_host():
+    assert build_success_url("http://localhost:8000/final/") == "http://localhost:8000/pay/final?session_id={CHECKOUT_SESSION_ID}"
+
+
+def test_build_success_url_drops_stale_query():
+    result = build_success_url("https://join.hackucf.org/final/?ref=email")
+    assert result == "https://join.hackucf.org/pay/final?session_id={CHECKOUT_SESSION_ID}"
+
+
+def test_pay_final_records_payment_when_webhook_never_fires(session: Session, client: TestClient, checkout_session_factory):
+    """The outage case: member returns from Stripe, webhook never arrives."""
+    payer = make_user(session)
+    jwt = Authentication.create_jwt(payer)
+    checkout = checkout_session_factory(id="cs_return_1", metadata={"user_id": str(payer.id)}, amount_total=1062)
+
+    # approve_member opens its own Session(engine) against the real database;
+    # TestClient runs background tasks inline, so it has to be stubbed here.
+    with (
+        patch("app.routes.stripe.stripe.checkout.Session.retrieve", return_value=checkout),
+        patch("app.routes.stripe.Approve.approve_member") as approve,
+    ):
+        response = client.get("/pay/final?session_id=cs_return_1", cookies={"token": jwt})
+
+    approve.assert_called_once()
+
+    assert response.status_code == 200
+    payments = session.exec(select(PaymentModel).where(PaymentModel.checkout_session_id == "cs_return_1")).all()
+    assert len(payments) == 1
+    assert payments[0].amount_cents == 1062
+    session.refresh(payer)
+    assert payer.did_pay_dues is True
+
+
+def test_pay_final_and_webhook_produce_one_payment(session: Session, client: TestClient, checkout_session_factory):
+    """Both paths processing the same session must not double-credit."""
+    payer = make_user(session)
+    jwt = Authentication.create_jwt(payer)
+    checkout = checkout_session_factory(id="cs_race_1", metadata={"user_id": str(payer.id)})
+
+    pay_dues(checkout, session, BackgroundTasks())
+    with patch("app.routes.stripe.stripe.checkout.Session.retrieve", return_value=checkout):
+        response = client.get("/pay/final?session_id=cs_race_1", cookies={"token": jwt})
+
+    assert response.status_code == 200
+    payments = session.exec(select(PaymentModel).where(PaymentModel.checkout_session_id == "cs_race_1")).all()
+    assert len(payments) == 1
+
+
+def test_pay_final_refuses_someone_elses_session(session: Session, client: TestClient, checkout_session_factory):
+    """Session ids come from a member-controlled query string."""
+    payer = make_user(session, email="payer@example.com")
+    attacker = make_user(session, email="attacker@example.com", discord_id="88888888888888888")
+    jwt = Authentication.create_jwt(attacker)
+    checkout = checkout_session_factory(id="cs_theft_1", metadata={"user_id": str(payer.id)})
+
+    with patch("app.routes.stripe.stripe.checkout.Session.retrieve", return_value=checkout):
+        response = client.get("/pay/final?session_id=cs_theft_1", cookies={"token": jwt})
+
+    assert response.status_code == 200
+    assert session.exec(select(PaymentModel)).all() == []
+    session.refresh(attacker)
+    session.refresh(payer)
+    assert attacker.did_pay_dues is False
+    assert payer.did_pay_dues is False
+
+
+def test_pay_final_ignores_unpaid_session(session: Session, client: TestClient, checkout_session_factory):
+    payer = make_user(session)
+    jwt = Authentication.create_jwt(payer)
+    checkout = checkout_session_factory(id="cs_unpaid_1", metadata={"user_id": str(payer.id)}, payment_status="unpaid")
+
+    with patch("app.routes.stripe.stripe.checkout.Session.retrieve", return_value=checkout):
+        response = client.get("/pay/final?session_id=cs_unpaid_1", cookies={"token": jwt})
+
+    assert response.status_code == 200
+    assert session.exec(select(PaymentModel)).all() == []
+
+
+def test_pay_final_renders_without_session_id(session: Session, client: TestClient):
+    """The join flow lands here too, with no session_id."""
+    payer = make_user(session)
+    jwt = Authentication.create_jwt(payer)
+    response = client.get("/pay/final", cookies={"token": jwt})
+    assert response.status_code == 200
+
+
+def test_pay_final_survives_stripe_being_down(session: Session, client: TestClient):
+    """A Stripe outage must not break the confirmation page."""
+    payer = make_user(session)
+    jwt = Authentication.create_jwt(payer)
+
+    with patch("app.routes.stripe.stripe.checkout.Session.retrieve", side_effect=stripe.APIConnectionError("down")):
+        response = client.get("/pay/final?session_id=cs_down_1", cookies={"token": jwt})
+
+    assert response.status_code == 200
+    assert session.exec(select(PaymentModel)).all() == []


### PR DESCRIPTION
## Problem

The `checkout.session.completed` webhook is the **only** path by which a payment is ever recorded. `success_url` pointed at a static page (`/final`, `app/main.py:506`) that renders `done.html` and ignores everything else.

So when the webhook is delayed or fails, the member pays, lands on a generic "done" page, and on their next visit sees the Pay button again with no indication their payment went through. Their only signal is a Stripe receipt email. Some of them pay twice — this has happened before, and the 41-hour outage from #405 made it likely again, since `did_pay_dues` was never set for anyone who paid in that window.

Note that a `did_pay_dues` guard on `/pay/checkout` would **not** fix this: during an outage `did_pay_dues` is never set, so the guard never fires. It only helps when the webhook already worked.

## Change

`GET /pay/final` — where Stripe now returns the member. It retrieves the session, confirms ownership, and calls the existing `pay_dues`.

The key property is that this was cheap: `pay_dues` already dedups on `checkout_session_id` with an `IntegrityError` guard, so it is safe to call from more than one source. The redirect and the webhook race harmlessly — whichever arrives first wins, the other no-ops. The webhook stays the source of truth for members who close the tab at Stripe's confirmation screen.

**The success URL path is pinned in code**, with only scheme and host taken from config. This is deliberate: during local testing the reconciliation silently did nothing because `url_success` still pointed at `/final/`, and Stripe's redirect landed on the page that ignores `session_id`. Checkout returned 200 and recorded nothing. Requiring a config update in both `config.yml` and Bitwarden to make the feature work is a silent-failure mode, and this PR exists because of silent failures.

Two smaller decisions:
- **Ownership is verified** before crediting — the session id arrives in a query string the member controls. UUIDs are compared parsed, not as strings.
- **Not gated on `pause_payments`** — pausing stops new sessions being created, but a member returning from one created beforehand still needs crediting. An unset API key surfaces as a caught `StripeError`.

## Testing

10 new tests. The three load-bearing ones were mutation-tested to confirm they aren't vacuous:

| Mutation | Test that caught it |
|---|---|
| ownership check always passes | `test_pay_final_refuses_someone_elses_session` |
| `payment_status` check removed | `test_pay_final_ignores_unpaid_session` |
| `safe="{}"` dropped (braces percent-encoded) | `test_build_success_url_*` |

Also covered: webhook never fires (the outage case), both paths processing the same session yielding exactly one `PaymentModel` row, Stripe unreachable, no `session_id` at all, and `test_build_success_url_pins_stale_configured_path` as a direct regression test for the `/final/` behaviour observed locally.

`uv run pytest` — 37 passed, 1 skipped. (`test_openvpn` fails on `dev` too; pre-existing, local-config dependent.)
`ruff check` / `ruff format --check` / `pyrefly check` — clean.

## Deploy note

No migration. `options-example.yml` is updated to document that only the origin of `url_success` is used; existing configs keep working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
