### PR TITLE
fix: exempt safe methods from CSRF checks

### DIFF
--- a/app/util/csrf.py
+++ b/app/util/csrf.py
@@ -21,9 +21,14 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             if path.startswith(bypass):
                 return await call_next(request)
 
-        method = request.method
+        # 1. Exempt safe methods
+        # Go behavior: GET/HEAD/OPTIONS short-circuit before any Fetch metadata is read.
+        # These cannot change state, so cross-site subresource loads (favicons, /static
+        # assets fetched from browser chrome or after a cross-site redirect) are fine.
+        if request.method in ["GET", "HEAD", "OPTIONS"]:
+            return await call_next(request)
 
-        # 1. Check Sec-Fetch-Site (Modern Browsers)
+        # 2. Check Sec-Fetch-Site (Modern Browsers)
         # Strict enforcement: Only allow same-origin and none.
         if "sec-fetch-site" in request.headers:
             sec_fetch_site = request.headers.get("sec-fetch-site")
@@ -33,9 +38,8 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             if sec_fetch_site in ["same-origin", "none"]:
                 return await call_next(request)
 
-            # Allow "navigate" mode (Top Level Navigation) for cross-site requests
-            if sec_fetch_mode == "navigate" and method in ["GET", "HEAD"]:
-                return await call_next(request)
+            # NOTE: cross-site "navigate" requests are only reachable here with an unsafe
+            # method (a cross-site form POST), which is the classic CSRF attack. Block it.
 
             # Check Trusted Origins (Whitelist) for cross-site/same-site requests
             origin = request.headers.get("origin")
@@ -45,7 +49,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             # Block everything else
             return await self._handle_violation(request, f"Blocked by Sec-Fetch-Site. Mode: {sec_fetch_mode}, Site: {sec_fetch_site}")
 
-        # 2. Fallback: Check Origin Header (Older Browsers / iOS 13)
+        # 3. Fallback: Check Origin Header (Older Browsers / iOS 13)
         origin = request.headers.get("origin")
         if origin:
             # Check Whitelist First
@@ -64,7 +68,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
             return await self._handle_violation(request, f"Origin Mismatch. Origin: {origin}, Host: {request.headers.get('host')}")
 
-        # 3. Neither header present -> Allow (Assume same-origin or non-browser)
+        # 4. Neither header present -> Allow (Assume same-origin or non-browser)
         return await call_next(request)
 
     def _is_trusted_origin(self, origin: str) -> bool:


### PR DESCRIPTION
## Problem

`CSRFMiddleware` evaluated `Sec-Fetch-*` metadata for every request regardless of HTTP method, so any cross-site `GET` was blocked with a 403 *and* captured in Sentry at `error` level.

Firefox labels favicon and other subresource fetches as `Sec-Fetch-Site: cross-site` when they originate from browser chrome (bookmarks, history, tab icon) or follow a cross-site navigation — including the return trip from the OAuth redirect. Those requests are `Sec-Fetch-Mode: no-cors` and carry no `Origin` header, so they missed every allow path in `dispatch`:

- `bypass_paths` defaults to `[]` and doesn't cover `/favicon.ico`
- `sec-fetch-site` is `cross-site`, so the `same-origin`/`none` allow missed
- `sec-fetch-mode` is `no-cors`, not `navigate`, so the navigation allow missed
- no `Origin` header, so the trusted-origins check couldn't help either

Result: the favicon route at `app/main.py:527` was never reached, and every such request produced a Sentry alert. This is the cause of the recurring `CSRF Violation: Blocked by Sec-Fetch-Site. Mode: no-cors, Site: cross-site | Path: /favicon.ico` errors.

The same gap applies to `/static/*` whenever a cross-site referrer is in play — `/favicon.ico` is just the most frequent instance.

## Fix

Hoist a `GET`/`HEAD`/`OPTIONS` short-circuit ahead of the header checks, matching Go's `http.CrossOriginProtection`, which exempts safe methods before reading any Fetch metadata. Safe methods can't change state, so they aren't CSRF-relevant.

The original code already knew this mattered — `method in ["GET", "HEAD"]` appeared inside the `navigate` branch — but the test was attached to that one narrow case instead of gating the whole middleware.

## Note on the removed branch

The cross-site `navigate` allowance becomes dead code: anything reaching it now carries an unsafe method, and a cross-site form `POST` is precisely the attack this middleware exists to stop. Replaced with a comment explaining why nothing is allowed through there.

## Security impact

None negative. Enforcement for state-changing methods (`POST`/`PUT`/`PATCH`/`DELETE`) is unchanged — all four allow paths and both violation handlers still apply. The change only stops blocking requests that were never a CSRF vector.

## Testing

- `ruff check` / `ruff format --check` clean
- `pyrefly check app/util/csrf.py` — 0 errors
- Existing test suite doesn't currently run locally (pre-existing `JwtConfig.secret` validation failure from the placeholder value in `config.yml`, unrelated to this change and present on `dev` without this patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)